### PR TITLE
left blank lines in order to dont move them

### DIFF
--- a/vimv
+++ b/vimv
@@ -27,7 +27,7 @@ IFS=$'\r\n' GLOBIGNORE='*' command eval  'dest=($(cat /tmp/vimv.$$))'
 
 count=0
 for ((i=0;i<${#src[@]};++i)); do
-    if [ "${src[i]}" != "${dest[i]}" ]; then
+    if [[ "${dest[i]}" != "-" && "${src[i]}" != "${dest[i]}" ]]; then
         $MOVE_CMD "${src[i]}" "${dest[i]}"
         ((count++))
     fi


### PR DESCRIPTION
If you decide to dont rename some files after opened, just put a `-`. Example:
```
Rick and Morty S01E01.mkv
Rick and Morty S01E02.mkv
-
Rick and Morty S01E04.mkv
Rick and Morty S01E05.mkv
Rick and Morty S02E01.mkv
```

It'll became this
```
S01E01.mkv
S01E02.mkv
Rick and Morty S01E03.mkv
S01E04.mkv
S01E05.mkv
S02E01.mkv
```