### PR TITLE
Check for git support per file

### DIFF
--- a/vimv
+++ b/vimv
@@ -10,12 +10,6 @@ else
     IFS=$'\r\n' GLOBIGNORE='*' command eval  'src=($(ls))'
 fi
 
-if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-    MOVE_CMD='git mv'
-else
-    MOVE_CMD='mv'
-fi
-
 touch /tmp/vimv.$$
 for ((i=0;i<${#src[@]};++i)); do
     echo "${src[i]}" >> /tmp/vimv.$$
@@ -28,7 +22,11 @@ IFS=$'\r\n' GLOBIGNORE='*' command eval  'dest=($(cat /tmp/vimv.$$))'
 count=0
 for ((i=0;i<${#src[@]};++i)); do
     if [ "${src[i]}" != "${dest[i]}" ]; then
-        $MOVE_CMD "${src[i]}" "${dest[i]}"
+        if git ls-files --error-unmatch "${src[i]}" > /dev/null 2>&1; then
+            git mv "${src[i]}" "${dest[i]}"
+        else
+            mv "${src[i]}" "${dest[i]}"
+        fi
         ((count++))
     fi
 done


### PR DESCRIPTION
Git can't move untracked files, so we have to check per file if git is
tracking it, rather then just checking if the whole directory is a repo.