### PR TITLE
delete the file with 'del' and use rmtrash if $VIMV_USE_RMTRASH is non empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Or simply copy the `vimv` file to a location in your `$PATH` and make it executa
 1. Go to a directory and enter `vimv` with optionally, a list of files to rename.
 2. A Vim window will be opened with names of all files.
 3. Use Vim's text editing features to edit the names of files. For example, search and replace a particular string, or use visual selection to delete a block.
-4. To delete a file/folder, replace the line with 'del' without the quotes.
+4. To delete a file/folder, replace the line with `del`
 5. Save and exit. Your files should be renamed now.
 
 ## Other features

--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ Or simply copy the `vimv` file to a location in your `$PATH` and make it executa
 1. Go to a directory and enter `vimv` with optionally, a list of files to rename.
 2. A Vim window will be opened with names of all files.
 3. Use Vim's text editing features to edit the names of files. For example, search and replace a particular string, or use visual selection to delete a block.
-4. Save and exit. Your files should be renamed now.
+4. To delete a file/folder, replace the line with 'del' without the quotes.
+5. Save and exit. Your files should be renamed now.
 
 ## Other features
 
 * If you want to list only a group of files, you can pass them as an argument. eg: `vimv *.mp4`
 * If you have an `$EDITOR` environment variable set, vimv will use its value by default.
+* If you have `rmtrash` in your path and you want vimv to use it, export the environnement variable `$VIMV_USE_RMTRASH`.
 * If you are inside a Git directory, vimv will use `git mv` (instead of `mv`) to rename the files.
 * You can use `/some/path/filename` format to move the file elsewhere during renaming. If the path is non-existent, it will be automatically created before moving.
 
@@ -30,4 +32,4 @@ Or simply copy the `vimv` file to a location in your `$PATH` and make it executa
 
 ## Gotchas
 
-Don't delete or swap the lines while in Vim or things will get ugly.
+Don't swap the lines while in Vim or things will get ugly.

--- a/vimv
+++ b/vimv
@@ -21,18 +21,27 @@ done
 ${EDITOR:-vi} "${FILENAMES_FILE}"
 
 IFS=$'\r\n' GLOBIGNORE='*' command eval  'dest=($(cat "${FILENAMES_FILE}"))'
-
-count=0
+renamed=0
+deleted=0
 for ((i=0;i<${#src[@]};++i)); do
     if [ "${src[i]}" != "${dest[i]}" ]; then
         mkdir -p "`dirname "${dest[i]}"`"
         if git ls-files --error-unmatch "${src[i]}" > /dev/null 2>&1; then
             git mv "${src[i]}" "${dest[i]}"
+            ((renamed++))
+        elif [ "del" = "${dest[i]}" ]; then # in vim replace the file name with 'del' to delete the file/dir
+            if [ ! -z $VIMV_USE_RMTRASH ]; then # export VIMV_USE_RMTRASH=1 to use rmtrash
+              rmtrash -rf "${src[i]}"
+            else
+              rm -rf "${src[i]}" 
+            fi
+            ((deleted++))
         else
             mv "${src[i]}" "${dest[i]}"
+            ((renamed++))
         fi
-        ((count++))
     fi
 done
 
-echo "$count" files renamed.
+echo "$renamed" files renamed.
+echo "$deleted" files deleted.

--- a/vimv
+++ b/vimv
@@ -27,10 +27,15 @@ for ((i=0;i<${#src[@]};++i)); do
     if [ "${src[i]}" != "${dest[i]}" ]; then
         mkdir -p "`dirname "${dest[i]}"`"
         if git ls-files --error-unmatch "${src[i]}" > /dev/null 2>&1; then
+          if [ "del" = "${dest[i]}" ]; then
+            git rm "${src[i]}"
+            ((deleted++))
+          else
             git mv "${src[i]}" "${dest[i]}"
             ((renamed++))
-        elif [ "del" = "${dest[i]}" ]; then # in vim replace the file name with 'del' to delete the file/dir
-            if [ ! -z $VIMV_USE_RMTRASH ]; then # export VIMV_USE_RMTRASH=1 to use rmtrash
+          fi
+        elif [ "del" = "${dest[i]}" ]; then
+            if [ ! -z $VIMV_USE_RMTRASH ]; then
               rmtrash -rf "${src[i]}"
             else
               rm -rf "${src[i]}" 


### PR DESCRIPTION
you can now use 'del' without the quote in the vim buffer to delete the file/dir corresponding.
if the variable `$VIMV_USE_RMTRASH` is set and non empty, vimv will use rmtrash to delete file/dir.

i don't have a lot of experience in shell scripting, tell me if you see a better solution. 
thanks