### PR TITLE
Support osx by using compatible `mktemp`

### DIFF
--- a/vimv
+++ b/vimv
@@ -4,7 +4,7 @@
 # USAGE: vimv [file1 file2]
 # https://github.com/thameera/vimv
 
-declare -r FILENAMES_FILE="$(mktemp --tmpdir vimv.XXX)"
+declare -r FILENAMES_FILE="$(mktemp "${TMPDIR:-/tmp/}vimv.XXX")"
 
 trap '{ rm -f "${FILENAMES_FILE}" ; }' EXIT
 


### PR DESCRIPTION
BSD `mktemp` doesn't support `--tmpdir` so instead we use the `-d` flag with an explicit filename template that uses `TMPDIR` if available, falling back to `/tmp`.