### PR TITLE
added: del entry, custom del cmd and del keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,16 @@ Or simply copy the `vimv` file to a location in your `$PATH` and make it executa
 
 1. Go to a directory and enter `vimv` with optionally, a list of files to rename.
 2. A Vim window will be opened with names of all files.
-3. Use Vim's text editing features to edit the names of files. For example, search and replace a particular string, or use visual selection to delete a block.
+3. Use Vim's text editing features to edit the names of files. For example, search and replace a particular string, or use visual selection to delete a block. to delete a file, replace the line of the entry with 'del' without the quote.
 4. Save and exit. Your files should be renamed now.
 
 ## Other features
 
 * If you want to list only a group of files, you can pass them as an argument. eg: `vimv *.mp4`
 * If you have an `$EDITOR` environment variable set, vimv will use its value by default.
-* If you are inside a Git directory, vimv will use `git mv` (instead of `mv`) to rename the files.
+* If `$VIMV_RM` is set, vimv will use its value as a rm command. Ex : `export VIMV_RM="rmtrash -rf"`. note the quote.
+* Use `$VIMV_DEL` to change the 'del' keyword. vimv will delete all entry regex-matching the value of `$VIMV_DEL` Ex : `export VIMV_DEL=^remove$`
+* If you are inside a Git directory, vimv will use `git mv` (instead of `mv`) to rename the files, and `git rm -rf` to remove files.
 * You can use `/some/path/filename` format to move the file elsewhere during renaming. If the path is non-existent, it will be automatically created before moving.
 
 ## Screencast

--- a/vimv
+++ b/vimv
@@ -9,30 +9,44 @@ declare -r FILENAMES_FILE="$(mktemp --tmpdir vimv.XXX)"
 trap '{ rm -f "${FILENAMES_FILE}" ; }' EXIT
 
 if [ $# -ne 0 ]; then
-    src=( "$@" )
+  src=( "$@" )
 else
-    IFS=$'\r\n' GLOBIGNORE='*' command eval  'src=($(ls))'
+  IFS=$'\r\n' GLOBIGNORE='*' command eval  'src=($(ls))'
 fi
 
 for ((i=0;i<${#src[@]};++i)); do
-    echo "${src[i]}" >> "${FILENAMES_FILE}"
+  echo "${src[i]}" >> "${FILENAMES_FILE}"
 done
 
 ${EDITOR:-vi} "${FILENAMES_FILE}"
 
 IFS=$'\r\n' GLOBIGNORE='*' command eval  'dest=($(cat "${FILENAMES_FILE}"))'
 
-count=0
+renamed=0
+removed=0
+
 for ((i=0;i<${#src[@]};++i)); do
-    if [ "${src[i]}" != "${dest[i]}" ]; then
-        mkdir -p "`dirname "${dest[i]}"`"
-        if git ls-files --error-unmatch "${src[i]}" > /dev/null 2>&1; then
-            git mv "${src[i]}" "${dest[i]}"
-        else
-            mv "${src[i]}" "${dest[i]}"
-        fi
-        ((count++))
+  if [ "${src[i]}" != "${dest[i]}" ]; then
+    mkdir -p "`dirname "${dest[i]}"`"
+
+    if git ls-files --error-unmatch "${src[i]}" > /dev/null 2>&1; then
+      if [[ "${dest[i]}" =~ ${VIMV_DEL:-^del$} ]]; then
+        git rm -rf "${src[i]}"
+        ((removed++))
+      else
+        git mv "${src[i]}" "${dest[i]}"
+        ((renamed++))
+      fi
+
+    elif [[ "${dest[i]}" =~ ${VIMV_DEL:-^del$} ]]; then
+      eval "${VIMV_RM:-rm -rf}" "${src[i]}" 
+      ((removed++))
+    else
+      mv "${src[i]}" "${dest[i]}"
+      ((renamed++))
     fi
+  fi
 done
 
-echo "$count" files renamed.
+echo "$renamed" files renamed.
+echo "$removed" files removed with ${VIMV_RM:-rm -rf}.


### PR DESCRIPTION
readme is updated with a explanation of the changes

to delete a entry, replace the file name with 'del' without the quote.
if `$VIMV_RM` is set, vimv will use its value as a rm command. ex : `export VIMV_RM="rmtrash -rf"`. note the quote.
use `$VIMV_DEL` to change the 'del' keyword. vimv will delete all entry regex-matching the value. ex : `export $VIMV_DEL=^remove$`

tell me what you think. thanks