### PR TITLE
Fix termination after first rename

### DIFF
--- a/vimv
+++ b/vimv
@@ -32,7 +32,7 @@ for ((i=0;i<${#src[@]};++i)); do
         else
             mv "${src[i]}" "${dest[i]}"
         fi
-        ((count++))
+        ((++count))
     fi
 done
 


### PR DESCRIPTION
Because `((count++))` was evaluating to 1 (see `help "(("`), the program was exiting after the first rename. This is fixed by changing the order of `++`.

Closes #28. See the issue for more details.