### PR TITLE
Check for accidentally deleted lines to prevent loss of files

### DIFF
--- a/vimv
+++ b/vimv
@@ -23,6 +23,11 @@ ${EDITOR:-vi} "${FILENAMES_FILE}"
 
 IFS=$'\r\n' GLOBIGNORE='*' command eval 'dest=($(cat "${FILENAMES_FILE}"))'
 
+if (( ${#src[@]} != ${#dest[@]} )); then
+    echo "WARN: Number of files changed. Did you delete a line by accident? Aborting.." >&2
+    exit 1
+fi
+
 declare -i count=0
 for ((i=0;i<${#src[@]};++i)); do
     if [ "${src[i]}" != "${dest[i]}" ]; then


### PR DESCRIPTION
Currently, there is no check when the user deletes a line during
editing, which can lead to lost files as demonstrated:

```sh
$ for i in $(seq 5); do echo $i > file_$i; done

$ for f in file_*; do echo "$f: $(cat $f)"; done
file_1: 1
file_2: 2
file_3: 3
file_4: 4
file_5: 5

$ EDITOR="sed -i 3d" vimv file_*
vimv: line 33: dest[i]: unbound variable

~/tmp/vimv
$ for f in file_*; do echo "$f: $(cat $f)"; done
file_1: 1
file_2: 2
file_5: 3
```

→ There is **data loss for the user**!

This change adds a simple check that aborts if the number of
destinations does not match the original number of sources.

```sh
$ EDITOR="sed -i 3d" vimv file_*
WARN: Number of files changed. Did you delete a line by accident? Aborting..

$ echo $?
1
```