### PR TITLE
README: install to ~/.local/bin instead of ~/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ vimv is a terminal-based file rename utility that lets you easily mass-rename fi
 
 1. For the current user:
    ```
-   curl https://raw.githubusercontent.com/thameera/vimv/master/vimv > ~/bin/vimv && chmod +755 ~/bin/vimv
+   curl https://raw.githubusercontent.com/thameera/vimv/master/vimv > ~/.local/bin/vimv && chmod +755 ~/.local/bin/vimv
    ```
 2. For the current system:
    ```


### PR DESCRIPTION
 - ~/.local/bin/ is used more commonly
   - ~/bin dir doesn't often even exist, aborting the installation.
   - Why should ~/bin be a non-hidden directory?
 - ~/.local/bin/ is in $PATH for many popular distros, whereas ~/bin/ is not.
   - ~/bin would have to be added to $PATH

 - ~/.opt would actually be a better fit, but it isn't commonly in $PATH.