### PR TITLE
Make vimv compatible with OpenBSD

### DIFF
--- a/vimv
+++ b/vimv
@@ -5,7 +5,7 @@ set -eu
 # USAGE: vimv [file1 file2]
 # https://github.com/thameera/vimv
 
-declare -r FILENAMES_FILE=$(mktemp "${TMPDIR:-/tmp}/vimv.XXX")
+declare -r FILENAMES_FILE=$(mktemp "${TMPDIR:-/tmp}/vimv.XXXXXX")
 
 trap '{ rm -f "${FILENAMES_FILE}" ; }' EXIT
 


### PR DESCRIPTION
OpenBSD's mktemp function requires at least 6 X's in the temp name template. This makes vimv compatible with OpenBSD, while also maintaining compatibility with all other os's!